### PR TITLE
Use onInput event instead of onChange to trigger query update

### DIFF
--- a/spotify/Events.elm
+++ b/spotify/Events.elm
@@ -1,5 +1,5 @@
 module Events
-  (onChange, onEnter)
+  (onInput, onEnter)
   where
 
 {-| Extensions to the Html.Events library.
@@ -25,6 +25,6 @@ is13 code =
   if code == 13 then Ok () else Err "not the right key code"
 
 
-onChange : Address a -> (String -> a) -> Html.Attribute
-onChange address f =
-  on "change" targetValue (message (forwardTo address f))
+onInput : Address a -> (String -> a) -> Html.Attribute
+onInput address f =
+  on "input" targetValue (message (forwardTo address f))

--- a/spotify/Search.elm
+++ b/spotify/Search.elm
@@ -2,7 +2,7 @@ module Search where
 
 import Effects exposing (Effects, Never)
 import Html exposing (..)
-import Events exposing (onChange, onEnter)
+import Events exposing (onInput, onEnter)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Http
@@ -99,7 +99,7 @@ inputForm address model =
     [ type' "text"
     , placeholder "Search for an album..."
     , value model.query
-    , onChange address QueryChange
+    , onInput address QueryChange
     , onEnter address Query
     ]
     []


### PR DESCRIPTION
This is a minor change that ensures model.query is kept updated as the user types. The change event is sometimes only fired after the search field loses focus or is committed, which can result in sending outdated queries to the Spotify API. The input event fires as the user types which fixes the issue. 

I'm aware that this is just an example project, but it's been really useful to me (as I'm just learning Elm) so I figured it would be nice to fix this for any other folks who may use this repo, in case they run into the same issue I did.

Thanks for the many instructional repos & for Elm, I'm loving it so far!
